### PR TITLE
Altered pluralisation of TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A [d3.js](https://d3js.org/) heatmap representing time series data. Inspired by 
 
 ![Reusable D3.js Calendar Heatmap chart](https://raw.githubusercontent.com/DKirwan/calendar-heatmap/develop/example/thumbnail.png)
 
-## TODO's
+## TODO
 
 * ~~Enable/disable tooltip~~
 * Editing of tooltip text


### PR DESCRIPTION
A very minor thing, the `'s` at the end of TODO is unnecessary.

I believe the original auther might be treating TODO as an acronym and making the quite common mistake that acronyms require an apostrophe before their ending 's' to denote pluralisation - but this is incorrect. For example, the plural of ATM is ATMs, not ATM's.

Luckily, `TODO` isn't really an acronym, it's a contraction of 'to do' or 'things to do'. As a result, it is compatible with multiple things already!

However as this is a language issue, there is no absolutely definitive way of writing anything. Ignore this is you want!