### PR TITLE
Performance improvement: Use temporary array to store data points days to enable faster filtering of the days

### DIFF
--- a/src/calendar-heatmap.js
+++ b/src/calendar-heatmap.js
@@ -198,11 +198,11 @@ function calendarHeatmap() {
       return count;
     }
 
+    var daysOfChart = chart.data().map(function(day){
+      return day.date.toDateString();
+    });
     dayRects.filter(function (d) {
-      var hasItem = chart.data().some(function (element, index) {
-        return moment(d).isSame(element.date, 'day');
-      });
-      return hasItem;
+      return daysOfChart.indexOf(d.toDateString()) > -1;
     }).attr('fill', function (d, i) {
       return color(chart.data()[i].count);
     });


### PR DESCRIPTION
Hi,

after commenting on:
https://github.com/DKirwan/calendar-heatmap/commit/5ee5557494b0764320903c7c6e48197805de999b

I checked better the code and it seems the filtering is needed to only process dates existing in the data points.
I refactored the code to enable a faster lookup.