### PR TITLE
Fix Tooltip Position

### DIFF
--- a/src/calendar-heatmap.js
+++ b/src/calendar-heatmap.js
@@ -113,7 +113,7 @@ function calendarHeatmap() {
 
       if (chart.tooltipEnabled()) {
         dayRects.on('mouseover', function (d, i) {
-          tooltip = d3.select('body')
+          tooltip = d3.select(chart.selector())
             .append('div')
             .attr('class', 'day-cell-tooltip')
             .html(tooltipHTMLForDate(d))


### PR DESCRIPTION
Tooltip selector selects 'body'. It should selects chart.selector() instead