### PR TITLE
Make countForDate very fast.

### DIFF
--- a/src/calendar-heatmap.js
+++ b/src/calendar-heatmap.js
@@ -11,6 +11,7 @@ function calendarHeatmap() {
   var now = moment().endOf('day').toDate();
   var yearAgo = moment().startOf('day').subtract(1, 'year').toDate();
   var startDate = null;
+  var counterMap= {};
   var data = [];
   var max = null;
   var colorRange = ['#D8E6E7', '#218380'];
@@ -32,6 +33,15 @@ function calendarHeatmap() {
   chart.data = function (value) {
     if (!arguments.length) { return data; }
     data = value;
+
+    counterMap= {};
+
+    data.forEach(function (element, index) {
+        var key= moment(element.date).format( 'YYYY-MM-DD' );
+        var counter= counterMap[key] || 0;
+        counterMap[key]= counter + element.count;
+    });
+
     return chart;
   };
 
@@ -244,14 +254,8 @@ function calendarHeatmap() {
     }
 
     function countForDate(d) {
-      var count = 0;
-      var match = chart.data().find(function (element, index) {
-        return moment(element.date).isSame(d, 'day');
-      });
-      if (match) {
-        count = match.count;
-      }
-      return count;
+        var key= moment(d).format( 'YYYY-MM-DD' );
+        return counterMap[key] || 0;
     }
 
     function formatWeekday(weekDay) {


### PR DESCRIPTION
To run the example page the javascript needs 1,57 seconds to render the chart. After using a map for the counter it needs only 105ms.

before the patch:
<img width="1366" alt="slow" src="https://user-images.githubusercontent.com/221964/39291596-d5943aa4-4933-11e8-8924-cf74ca5965bd.png">

with the patch:
<img width="1345" alt="fast" src="https://user-images.githubusercontent.com/221964/39291612-e241ee9a-4933-11e8-89c1-9a372c77b403.png">

About 15x faster 😃 